### PR TITLE
Upgrade to logr v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/PowerDNS/go-tlsconfig
 
-go 1.14
+go 1.18
 
 require (
-	github.com/go-logr/logr v0.2.1
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/go-logr/logr v1.2.3
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
-github.com/go-logr/logr v0.2.1 h1:fV3MLmabKIZ383XifUjFSwcoGee0v9qgPp8wy5svibE=
-github.com/go-logr/logr v0.2.1/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/manager.go
+++ b/manager.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/PowerDNS/go-tlsconfig/filewatcher"
 	"github.com/go-logr/logr"
-	logrtesting "github.com/go-logr/logr/testing"
 )
 
 // Options configure how the Manager works and performs Config validation
@@ -44,8 +43,14 @@ func NewManager(ctx context.Context, config Config, options Options) (*Manager, 
 		return nil, fmt.Errorf("options: one of IsServer and IsClient is required")
 	}
 	log := options.Logr
-	if log == nil {
-		log = logrtesting.NullLogger{}
+	// TODO: Since v1 this is a concrete type and we can no longer compare with
+	//       nil. Unfortunately, there is no clean way to check this against a
+	//       zero type either and we do not want to change the signature of
+	//       the option if not needed, so instead we check if the LogSink is nil
+	//       to determine if it is uninitialized.
+	//       See https://github.com/go-logr/logr/issues/152
+	if log.GetSink() == nil {
+		log = logr.Discard()
 	}
 
 	// Create a Manager

--- a/testca/testca_test.go
+++ b/testca/testca_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/PowerDNS/go-tlsconfig"
+	"github.com/go-logr/logr/testr"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -69,7 +70,7 @@ func TestTestCA_client_server(t *testing.T) {
 		serverManager, err := tlsconfig.NewManager(ctx, serverConfig, tlsconfig.Options{
 			IsServer:          true,
 			RequireClientCert: true,
-			Logr:              nil,
+			Logr:              testr.New(t),
 		})
 		if err != nil {
 			return err
@@ -112,7 +113,7 @@ func TestTestCA_client_server(t *testing.T) {
 		clientManager, err := tlsconfig.NewManager(ctx, clientConfig, tlsconfig.Options{
 			IsClient:          true,
 			RequireClientCert: true,
-			Logr:              nil,
+			Logr:              testr.New(t),
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Upgrade to logr v1, which introduces breaking changes. logr.Logger is now a struct that is passed by value, instead of an interface.